### PR TITLE
fix: Add explicit return to NavigationMenu useEffect

### DIFF
--- a/src/components/NavigationMenu.tsx
+++ b/src/components/NavigationMenu.tsx
@@ -273,6 +273,7 @@ export default function NavigationMenu() {
       document.addEventListener('click', handleClickOutside);
       return () => document.removeEventListener('click', handleClickOutside);
     }
+    return undefined;
   }, [isMobile, activeDropdown]);
 
   // Detect mobile screen size


### PR DESCRIPTION
- Final TypeScript fix for missing return in all code paths
- Add return undefined to mobile dropdown useEffect

THIS MUST BE THE LAST ERROR!

🤖 Generated with [Claude Code](https://claude.ai/code)